### PR TITLE
[Hotfix] installer script (assets path)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -19,3 +19,4 @@ lib/*
 *.zip
 
 int-ball2_isaac_sim/assets
+int-ball2_data_replay/bags

--- a/README.md
+++ b/README.md
@@ -177,7 +177,7 @@ Those ROSBags are publicily available in [HuggingFace](https://huggingface.co/da
 ```bash
 cd ~/int-ball2_ws/src/int-ball2_isaac_sim/int-ball2_data_replay/
 # Choose the ROSbag you want to download
-huggingface-cli download --repo-type dataset --local-dir ./ SpaceData/int-ball2_data_on_iss bags/rosbag_20250421111514.bag
+hf download --repo-type dataset --local-dir ./ SpaceData/int-ball2_data_on_iss bags/rosbag_20250421111514.bag
 ```
 2. Remember that the actual Int-Ball2 runs on ROS Melodic, then we need to convert the ROSBag so that is playable in ROS2 using [Rosbags](https://gitlab.com/ternaris/rosbags).
 ```bash

--- a/README_JA.md
+++ b/README_JA.md
@@ -180,7 +180,7 @@ SpaceDataは、ISS上の実機Int-Ball2のデータを収集する機会を得�
 ```bash
 cd ~/int-ball2_ws/src/int-ball2_isaac_sim/int-ball2_data_replay/
 # ダウンロードしたいROSBagsを選択してください
-huggingface-cli download --repo-type dataset --local-dir ./ SpaceData/int-ball2_data_on_iss bags/rosbag_20250421111514.bag
+hf download --repo-type dataset --local-dir ./ SpaceData/int-ball2_data_on_iss bags/rosbag_20250421111514.bag
 ```
 2. 実機Int-Ball2はROS Melodicで動作しているため、[Rosbags](https://gitlab.com/ternaris/rosbags)を使ってROS2で再生できる形式に変換します。
 ```bash

--- a/install_local.sh
+++ b/install_local.sh
@@ -23,7 +23,7 @@ PKG_DIR=$(pwd)                                 # .../intball2_ws/src/int-ball2_i
 SRC_DIR=$(dirname "$PKG_DIR")                  # .../intball2_ws/src
 WS_DIR=$(realpath "$SRC_DIR/..")               # .../intball2_ws
 
-cd "$PKG_DIR"
+cd $PKG_DIR/int-ball2_isaac_sim
 
 # Download the folder as a ZIP file
 echo "Starting download of assets..."


### PR DESCRIPTION
This PR fixes the following points:
- `assets` was not downloaded in the correct path
- `huggingface-cli` will be deprecated, `hf` is used now
- Add downloaded rosbags for replay to `.gitignore`.